### PR TITLE
Add frame ancestor configuration for web app to prevent clickjacking

### DIFF
--- a/cmd/dex/config.go
+++ b/cmd/dex/config.go
@@ -150,6 +150,7 @@ type Web struct {
 	TLSCert        string   `json:"tlsCert"`
 	TLSKey         string   `json:"tlsKey"`
 	AllowedOrigins []string `json:"allowedOrigins"`
+	FrameAncestors []string `json:"frameAncestors"`
 }
 
 // Telemetry is the config format for telemetry including the HTTP server config.

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -253,6 +253,10 @@ func runServe(options serveOptions) error {
 		logger.Infof("config allowed origins: %s", c.Web.AllowedOrigins)
 	}
 
+	if len(c.Web.FrameAncestors) > 0 {
+		logger.Infof("config allowed frame ancestors: %s", c.Web.FrameAncestors)
+	}
+
 	// explicitly convert to UTC.
 	now := func() time.Time { return time.Now().UTC() }
 

--- a/server/oauth2.go
+++ b/server/oauth2.go
@@ -135,12 +135,12 @@ const (
 )
 
 const (
-	responseTypeCode    = "code"     // "Regular" flow
-	responseTypeToken   = "token"    // Implicit flow for frontend apps.
-	responseTypeIDToken = "id_token" // ID Token in url fragment
-	responseTypeCodeToken = "code token" // "Regular" flow + Implicit flow
-	responseTypeCodeIDToken = "code id_token" // "Regular" flow + ID Token
-	responseTypeIDTokenToken = "id_token token" // ID Token + Implicit flow
+	responseTypeCode             = "code"                // "Regular" flow
+	responseTypeToken            = "token"               // Implicit flow for frontend apps.
+	responseTypeIDToken          = "id_token"            // ID Token in url fragment
+	responseTypeCodeToken        = "code token"          // "Regular" flow + Implicit flow
+	responseTypeCodeIDToken      = "code id_token"       // "Regular" flow + ID Token
+	responseTypeIDTokenToken     = "id_token token"      // ID Token + Implicit flow
 	responseTypeCodeIDTokenToken = "code id_token token" // "Regular" flow + ID Token + Implicit flow
 )
 

--- a/server/oauth2.go
+++ b/server/oauth2.go
@@ -138,6 +138,10 @@ const (
 	responseTypeCode    = "code"     // "Regular" flow
 	responseTypeToken   = "token"    // Implicit flow for frontend apps.
 	responseTypeIDToken = "id_token" // ID Token in url fragment
+	responseTypeCodeToken = "code token" // "Regular" flow + Implicit flow
+	responseTypeCodeIDToken = "code id_token" // "Regular" flow + ID Token
+	responseTypeIDTokenToken = "id_token token" // ID Token + Implicit flow
+	responseTypeCodeIDTokenToken = "code id_token token" // "Regular" flow + ID Token + Implicit flow
 )
 
 const (

--- a/server/server.go
+++ b/server/server.go
@@ -218,9 +218,9 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 
 	for _, respType := range c.SupportedResponseTypes {
 		switch respType {
-		case responseTypeCode, responseTypeIDToken:
+		case responseTypeCode, responseTypeIDToken, responseTypeCodeIDToken:
 			// continue
-		case responseTypeToken:
+		case responseTypeToken, responseTypeCodeToken, responseTypeIDTokenToken, responseTypeCodeIDTokenToken:
 			// response_type=token is an implicit flow, let's add it to the discovery info
 			// https://datatracker.ietf.org/doc/html/rfc6749#section-4.2.1
 			supportedGrant = append(supportedGrant, grantTypeImplicit)

--- a/server/server.go
+++ b/server/server.go
@@ -77,6 +77,11 @@ type Config struct {
 	// domain.
 	AllowedOrigins []string
 
+	// List of domain allowed to frame the content of the application.
+	// By default no one is accepted to prevent against clickjacking.
+	// Passing in "*" will allow any domain
+	FrameAncestors []string
+
 	// If enabled, the server won't prompt the user to approve authorization requests.
 	// Logging in implies approval.
 	SkipApprovalScreen bool
@@ -339,7 +344,28 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 		}
 	}
 
+
+	// frame-ancestors middleware
+	frameAncestorsMidldleware := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var ancestors string
+			if len(c.FrameAncestors) > 0 {
+				for i := 0; i < len(c.FrameAncestors); i++ {
+					if c.FrameAncestors[i] == issuerURL.String() {
+						c.FrameAncestors[i] = "'self'"
+					}
+				}
+				ancestors = strings.Join(c.FrameAncestors, " ")
+			} else {
+				ancestors = "'none'"
+			}
+			w.Header().Set("Content-Security-Policy", "frame-ancestors "+ancestors)
+			next.ServeHTTP(w, r)
+		})
+	}
+
 	r := mux.NewRouter().SkipClean(true).UseEncodedPath()
+	r.Use(frameAncestorsMidldleware)
 	handle := func(p string, h http.Handler) {
 		r.Handle(path.Join(issuerURL.Path, p), instrumentHandlerCounter(p, h))
 	}


### PR DESCRIPTION
Overview

Provide a way to configure the Content Security Policy frame-ancestor context to prevent clickjacking
What this PR does / why we need it

This PR enables the configuration of the Content-Security policy to prevent clickjacking. By filling dex configuration with the specific fields the application will send csp headers in responses defining the content security policy.

available CSP:
○ No domain could frame the content (recommended unless a specific need has been identified for framing.) DEFAULT
○ Only the current site could frame the content
○ Only certain site could frame the content (must specify the protocol)
○ No CSP (ie any domain could frame the content, INSECURE)
Special notes for your reviewer

The most critical endpoints for clickjacking is the /dex/auth one (as a user interaction is needed to provide credential) but by default it is a good point to apply the same policy for all endpoints
Does this PR introduce a user-facing change?

NONE
