### PR TITLE
feat: support passing extra params to auth url

### DIFF
--- a/server/deviceflowhandlers.go
+++ b/server/deviceflowhandlers.go
@@ -88,6 +88,24 @@ func (s *Server) handleDeviceCode(w http.ResponseWriter, r *http.Request) {
 
 		s.logger.Infof("Received device request for client %v with scopes %v", clientID, scopes)
 
+		// Collect any extra params to forward to /auth (e.g. connector_id)
+		knownParams := map[string]bool{
+			"client_id":             true,
+			"client_secret":         true,
+			"scope":                 true,
+			"code_challenge":        true,
+			"code_challenge_method": true,
+		}
+		var extraParams map[string]string
+		for key, vals := range r.Form {
+			if !knownParams[key] && len(vals) > 0 {
+				if extraParams == nil {
+					extraParams = make(map[string]string)
+				}
+				extraParams[key] = vals[0]
+			}
+		}
+
 		// Make device code
 		deviceCode := storage.NewDeviceCode()
 
@@ -105,6 +123,7 @@ func (s *Server) handleDeviceCode(w http.ResponseWriter, r *http.Request) {
 			ClientSecret: clientSecret,
 			Scopes:       scopes,
 			Expiry:       expireTime,
+			ExtraParams:  extraParams,
 		}
 
 		if err := s.storage.CreateDeviceRequest(ctx, deviceReq); err != nil {
@@ -436,6 +455,9 @@ func (s *Server) verifyUserCode(w http.ResponseWriter, r *http.Request) {
 		q.Set("response_type", "code")
 		q.Set("redirect_uri", fmt.Sprintf("%s/device/callback", s.issuerURL.Path))
 		q.Set("scope", strings.Join(deviceRequest.Scopes, " "))
+		for key, val := range deviceRequest.ExtraParams {
+			q.Set(key, val)
+		}
 		u.RawQuery = q.Encode()
 
 		http.Redirect(w, r, u.String(), http.StatusFound)

--- a/storage/ent/client/devicerequest.go
+++ b/storage/ent/client/devicerequest.go
@@ -17,6 +17,7 @@ func (d *Database) CreateDeviceRequest(ctx context.Context, request storage.Devi
 		SetDeviceCode(request.DeviceCode).
 		// Save utc time into database because ent doesn't support comparing dates with different timezones
 		SetExpiry(request.Expiry.UTC()).
+		SetNillableExtraParams(request.ExtraParams).
 		Save(ctx)
 	if err != nil {
 		return convertDBError("create device request: %w", err)

--- a/storage/ent/client/types.go
+++ b/storage/ent/client/types.go
@@ -154,6 +154,7 @@ func toStorageDeviceRequest(r *db.DeviceRequest) storage.DeviceRequest {
 		ClientSecret: r.ClientSecret,
 		Scopes:       r.Scopes,
 		Expiry:       r.Expiry,
+		ExtraParams:  r.ExtraParams,
 	}
 }
 

--- a/storage/ent/db/devicerequest.go
+++ b/storage/ent/db/devicerequest.go
@@ -29,7 +29,9 @@ type DeviceRequest struct {
 	// Scopes holds the value of the "scopes" field.
 	Scopes []string `json:"scopes,omitempty"`
 	// Expiry holds the value of the "expiry" field.
-	Expiry       time.Time `json:"expiry,omitempty"`
+	Expiry time.Time `json:"expiry,omitempty"`
+	// ExtraParams holds the value of the "extra_params" field.
+	ExtraParams  map[string]string `json:"extra_params,omitempty"`
 	selectValues sql.SelectValues
 }
 
@@ -38,7 +40,7 @@ func (*DeviceRequest) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case devicerequest.FieldScopes:
+		case devicerequest.FieldScopes, devicerequest.FieldExtraParams:
 			values[i] = new([]byte)
 		case devicerequest.FieldID:
 			values[i] = new(sql.NullInt64)
@@ -105,6 +107,14 @@ func (dr *DeviceRequest) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				dr.Expiry = value.Time
 			}
+		case devicerequest.FieldExtraParams:
+			if value, ok := values[i].(*[]byte); !ok {
+				return fmt.Errorf("unexpected type %T for field extra_params", values[i])
+			} else if value != nil && len(*value) > 0 {
+				if err := json.Unmarshal(*value, &dr.ExtraParams); err != nil {
+					return fmt.Errorf("unmarshal field extra_params: %w", err)
+				}
+			}
 		default:
 			dr.selectValues.Set(columns[i], values[i])
 		}
@@ -158,6 +168,9 @@ func (dr *DeviceRequest) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("expiry=")
 	builder.WriteString(dr.Expiry.Format(time.ANSIC))
+	builder.WriteString(", ")
+	builder.WriteString("extra_params=")
+	builder.WriteString(fmt.Sprintf("%v", dr.ExtraParams))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/storage/ent/db/devicerequest/devicerequest.go
+++ b/storage/ent/db/devicerequest/devicerequest.go
@@ -23,6 +23,8 @@ const (
 	FieldScopes = "scopes"
 	// FieldExpiry holds the string denoting the expiry field in the database.
 	FieldExpiry = "expiry"
+	// FieldExtraParams holds the string denoting the extra_params field in the database.
+	FieldExtraParams = "extra_params"
 	// Table holds the table name of the devicerequest in the database.
 	Table = "device_requests"
 )
@@ -36,6 +38,7 @@ var Columns = []string{
 	FieldClientSecret,
 	FieldScopes,
 	FieldExpiry,
+	FieldExtraParams,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).

--- a/storage/ent/db/devicerequest_create.go
+++ b/storage/ent/db/devicerequest_create.go
@@ -56,6 +56,20 @@ func (drc *DeviceRequestCreate) SetExpiry(t time.Time) *DeviceRequestCreate {
 	return drc
 }
 
+// SetExtraParams sets the "extra_params" field.
+func (drc *DeviceRequestCreate) SetExtraParams(m map[string]string) *DeviceRequestCreate {
+	drc.mutation.SetExtraParams(m)
+	return drc
+}
+
+// SetNillableExtraParams sets the "extra_params" field if the given value is not nil.
+func (drc *DeviceRequestCreate) SetNillableExtraParams(m map[string]string) *DeviceRequestCreate {
+	if m != nil {
+		drc.SetExtraParams(m)
+	}
+	return drc
+}
+
 // Mutation returns the DeviceRequestMutation object of the builder.
 func (drc *DeviceRequestCreate) Mutation() *DeviceRequestMutation {
 	return drc.mutation
@@ -174,6 +188,10 @@ func (drc *DeviceRequestCreate) createSpec() (*DeviceRequest, *sqlgraph.CreateSp
 	if value, ok := drc.mutation.Expiry(); ok {
 		_spec.SetField(devicerequest.FieldExpiry, field.TypeTime, value)
 		_node.Expiry = value
+	}
+	if value, ok := drc.mutation.ExtraParams(); ok {
+		_spec.SetField(devicerequest.FieldExtraParams, field.TypeJSON, value)
+		_node.ExtraParams = value
 	}
 	return _node, _spec
 }

--- a/storage/ent/db/migrate/schema.go
+++ b/storage/ent/db/migrate/schema.go
@@ -86,6 +86,7 @@ var (
 		{Name: "client_secret", Type: field.TypeString, Size: 2147483647, SchemaType: map[string]string{"mysql": "varchar(384)", "postgres": "text", "sqlite3": "text"}},
 		{Name: "scopes", Type: field.TypeJSON, Nullable: true},
 		{Name: "expiry", Type: field.TypeTime, SchemaType: map[string]string{"mysql": "datetime(3)", "postgres": "timestamptz", "sqlite3": "timestamp"}},
+		{Name: "extra_params", Type: field.TypeJSON, Nullable: true},
 	}
 	// DeviceRequestsTable holds the schema information for the "device_requests" table.
 	DeviceRequestsTable = &schema.Table{

--- a/storage/ent/db/mutation.go
+++ b/storage/ent/db/mutation.go
@@ -3224,6 +3224,7 @@ type DeviceRequestMutation struct {
 	scopes        *[]string
 	appendscopes  []string
 	expiry        *time.Time
+	extra_params  map[string]string
 	clearedFields map[string]struct{}
 	done          bool
 	oldValue      func(context.Context) (*DeviceRequest, error)
@@ -3573,6 +3574,53 @@ func (m *DeviceRequestMutation) ResetExpiry() {
 	m.expiry = nil
 }
 
+// SetExtraParams sets the "extra_params" field.
+func (m *DeviceRequestMutation) SetExtraParams(mp map[string]string) {
+	m.extra_params = mp
+}
+
+// ExtraParams returns the value of the "extra_params" field in the mutation.
+func (m *DeviceRequestMutation) ExtraParams() (r map[string]string, exists bool) {
+	v := m.extra_params
+	if v == nil {
+		return
+	}
+	return v, true
+}
+
+// OldExtraParams returns the old "extra_params" field's value of the DeviceRequest entity.
+func (m *DeviceRequestMutation) OldExtraParams(ctx context.Context) (v map[string]string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldExtraParams is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldExtraParams requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldExtraParams: %w", err)
+	}
+	return oldValue.ExtraParams, nil
+}
+
+// ClearExtraParams clears the value of the "extra_params" field.
+func (m *DeviceRequestMutation) ClearExtraParams() {
+	m.extra_params = nil
+	m.clearedFields[devicerequest.FieldExtraParams] = struct{}{}
+}
+
+// ExtraParamsCleared returns if the "extra_params" field was cleared in this mutation.
+func (m *DeviceRequestMutation) ExtraParamsCleared() bool {
+	_, ok := m.clearedFields[devicerequest.FieldExtraParams]
+	return ok
+}
+
+// ResetExtraParams resets all changes to the "extra_params" field.
+func (m *DeviceRequestMutation) ResetExtraParams() {
+	m.extra_params = nil
+	delete(m.clearedFields, devicerequest.FieldExtraParams)
+}
+
 // Where appends a list predicates to the DeviceRequestMutation builder.
 func (m *DeviceRequestMutation) Where(ps ...predicate.DeviceRequest) {
 	m.predicates = append(m.predicates, ps...)
@@ -3607,7 +3655,7 @@ func (m *DeviceRequestMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *DeviceRequestMutation) Fields() []string {
-	fields := make([]string, 0, 6)
+	fields := make([]string, 0, 7)
 	if m.user_code != nil {
 		fields = append(fields, devicerequest.FieldUserCode)
 	}
@@ -3625,6 +3673,9 @@ func (m *DeviceRequestMutation) Fields() []string {
 	}
 	if m.expiry != nil {
 		fields = append(fields, devicerequest.FieldExpiry)
+	}
+	if m.extra_params != nil {
+		fields = append(fields, devicerequest.FieldExtraParams)
 	}
 	return fields
 }
@@ -3646,6 +3697,8 @@ func (m *DeviceRequestMutation) Field(name string) (ent.Value, bool) {
 		return m.Scopes()
 	case devicerequest.FieldExpiry:
 		return m.Expiry()
+	case devicerequest.FieldExtraParams:
+		return m.ExtraParams()
 	}
 	return nil, false
 }
@@ -3667,6 +3720,8 @@ func (m *DeviceRequestMutation) OldField(ctx context.Context, name string) (ent.
 		return m.OldScopes(ctx)
 	case devicerequest.FieldExpiry:
 		return m.OldExpiry(ctx)
+	case devicerequest.FieldExtraParams:
+		return m.OldExtraParams(ctx)
 	}
 	return nil, fmt.Errorf("unknown DeviceRequest field %s", name)
 }
@@ -3718,6 +3773,13 @@ func (m *DeviceRequestMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetExpiry(v)
 		return nil
+	case devicerequest.FieldExtraParams:
+		v, ok := value.(map[string]string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetExtraParams(v)
+		return nil
 	}
 	return fmt.Errorf("unknown DeviceRequest field %s", name)
 }
@@ -3751,6 +3813,9 @@ func (m *DeviceRequestMutation) ClearedFields() []string {
 	if m.FieldCleared(devicerequest.FieldScopes) {
 		fields = append(fields, devicerequest.FieldScopes)
 	}
+	if m.FieldCleared(devicerequest.FieldExtraParams) {
+		fields = append(fields, devicerequest.FieldExtraParams)
+	}
 	return fields
 }
 
@@ -3767,6 +3832,9 @@ func (m *DeviceRequestMutation) ClearField(name string) error {
 	switch name {
 	case devicerequest.FieldScopes:
 		m.ClearScopes()
+		return nil
+	case devicerequest.FieldExtraParams:
+		m.ClearExtraParams()
 		return nil
 	}
 	return fmt.Errorf("unknown DeviceRequest nullable field %s", name)
@@ -3793,6 +3861,9 @@ func (m *DeviceRequestMutation) ResetField(name string) error {
 		return nil
 	case devicerequest.FieldExpiry:
 		m.ResetExpiry()
+		return nil
+	case devicerequest.FieldExtraParams:
+		m.ResetExtraParams()
 		return nil
 	}
 	return fmt.Errorf("unknown DeviceRequest field %s", name)

--- a/storage/ent/schema/devicerequest.go
+++ b/storage/ent/schema/devicerequest.go
@@ -42,6 +42,8 @@ func (DeviceRequest) Fields() []ent.Field {
 			Optional(),
 		field.Time("expiry").
 			SchemaType(timeSchema),
+		field.JSON("extra_params", map[string]string{}).
+			Optional(),
 	}
 }
 

--- a/storage/etcd/types.go
+++ b/storage/etcd/types.go
@@ -258,12 +258,13 @@ func toStorageOfflineSessions(o OfflineSessions) storage.OfflineSessions {
 
 // DeviceRequest is a mirrored struct from storage with JSON struct tags
 type DeviceRequest struct {
-	UserCode     string    `json:"user_code"`
-	DeviceCode   string    `json:"device_code"`
-	ClientID     string    `json:"client_id"`
-	ClientSecret string    `json:"client_secret"`
-	Scopes       []string  `json:"scopes"`
-	Expiry       time.Time `json:"expiry"`
+	UserCode     string            `json:"user_code"`
+	DeviceCode   string            `json:"device_code"`
+	ClientID     string            `json:"client_id"`
+	ClientSecret string            `json:"client_secret"`
+	Scopes       []string          `json:"scopes"`
+	Expiry       time.Time         `json:"expiry"`
+	ExtraParams  map[string]string `json:"extra_params,omitempty"`
 }
 
 func fromStorageDeviceRequest(d storage.DeviceRequest) DeviceRequest {
@@ -274,6 +275,7 @@ func fromStorageDeviceRequest(d storage.DeviceRequest) DeviceRequest {
 		ClientSecret: d.ClientSecret,
 		Scopes:       d.Scopes,
 		Expiry:       d.Expiry,
+		ExtraParams:  d.ExtraParams,
 	}
 }
 
@@ -285,6 +287,7 @@ func toStorageDeviceRequest(d DeviceRequest) storage.DeviceRequest {
 		ClientSecret: d.ClientSecret,
 		Scopes:       d.Scopes,
 		Expiry:       d.Expiry,
+		ExtraParams:  d.ExtraParams,
 	}
 }
 

--- a/storage/kubernetes/types.go
+++ b/storage/kubernetes/types.go
@@ -751,11 +751,12 @@ type DeviceRequest struct {
 	k8sapi.TypeMeta   `json:",inline"`
 	k8sapi.ObjectMeta `json:"metadata,omitempty"`
 
-	DeviceCode   string    `json:"device_code,omitempty"`
-	ClientID     string    `json:"client_id,omitempty"`
-	ClientSecret string    `json:"client_secret,omitempty"`
-	Scopes       []string  `json:"scopes,omitempty"`
-	Expiry       time.Time `json:"expiry"`
+	DeviceCode   string            `json:"device_code,omitempty"`
+	ClientID     string            `json:"client_id,omitempty"`
+	ClientSecret string            `json:"client_secret,omitempty"`
+	Scopes       []string          `json:"scopes,omitempty"`
+	Expiry       time.Time         `json:"expiry"`
+	ExtraParams  map[string]string `json:"extra_params,omitempty"`
 }
 
 // DeviceRequestList is a list of DeviceRequests.
@@ -780,6 +781,7 @@ func (cli *client) fromStorageDeviceRequest(a storage.DeviceRequest) DeviceReque
 		ClientSecret: a.ClientSecret,
 		Scopes:       a.Scopes,
 		Expiry:       a.Expiry,
+		ExtraParams:  a.ExtraParams,
 	}
 	return req
 }
@@ -792,6 +794,7 @@ func toStorageDeviceRequest(req DeviceRequest) storage.DeviceRequest {
 		ClientSecret: req.ClientSecret,
 		Scopes:       req.Scopes,
 		Expiry:       req.Expiry,
+		ExtraParams:  req.ExtraParams,
 	}
 }
 

--- a/storage/sql/crud.go
+++ b/storage/sql/crud.go
@@ -913,12 +913,12 @@ func (c *conn) delete(table, field, id string) error {
 func (c *conn) CreateDeviceRequest(ctx context.Context, d storage.DeviceRequest) error {
 	_, err := c.Exec(`
 		insert into device_request (
-			user_code, device_code, client_id, client_secret, scopes, expiry
+			user_code, device_code, client_id, client_secret, scopes, expiry, extra_params
 		)
 		values (
-			$1, $2, $3, $4, $5, $6
+			$1, $2, $3, $4, $5, $6, $7
 		);`,
-		d.UserCode, d.DeviceCode, d.ClientID, d.ClientSecret, encoder(d.Scopes), d.Expiry,
+		d.UserCode, d.DeviceCode, d.ClientID, d.ClientSecret, encoder(d.Scopes), d.Expiry, encoder(d.ExtraParams),
 	)
 	if err != nil {
 		if c.alreadyExistsCheck(err) {
@@ -955,10 +955,10 @@ func (c *conn) GetDeviceRequest(userCode string) (storage.DeviceRequest, error) 
 func getDeviceRequest(q querier, userCode string) (d storage.DeviceRequest, err error) {
 	err = q.QueryRow(`
 		select
-            device_code, client_id, client_secret, scopes, expiry
+            device_code, client_id, client_secret, scopes, expiry, extra_params
 		from device_request where user_code = $1;
 	`, userCode).Scan(
-		&d.DeviceCode, &d.ClientID, &d.ClientSecret, decoder(&d.Scopes), &d.Expiry,
+		&d.DeviceCode, &d.ClientID, &d.ClientSecret, decoder(&d.Scopes), &d.Expiry, decoder(&d.ExtraParams),
 	)
 	if err != nil {
 		if err == sql.ErrNoRows {

--- a/storage/sql/migrate.go
+++ b/storage/sql/migrate.go
@@ -298,4 +298,11 @@ var migrations = []migration{
 				add column hmac_key bytea;`,
 		},
 	},
+	{
+		stmts: []string{
+			`
+			alter table device_request
+				add column extra_params bytea;`,
+		},
+	},
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -431,6 +431,8 @@ type DeviceRequest struct {
 	Scopes []string
 	// The expire time
 	Expiry time.Time
+	// Extra parameters to forward to the authorization endpoint (e.g. connector_id)
+	ExtraParams map[string]string
 }
 
 // DeviceToken is a structure which represents the actual token of an authorized device and its rotation parameters


### PR DESCRIPTION
This PR enables us to pass any extra parameter to the authorization URL from aToME when authenticating to a cluster using the `device` flow.

**Why ?**

We need to have a `connector_id` parameter in order to bypass the connectors choice; In our case, the connectors choice is not needed because we only ONE connector for human authentication:
* Multipass Device (using GWARD's device flow)
* Multipass Client (using GWARD's client_credentials flow)

This is just a UX improvement.

**Tested ?**

Duh.