### PR TITLE
Request to merge feature/orange_support_certificate_connector_2.45 to support-v2.45.1-orange

### DIFF
--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -610,6 +610,7 @@ func applyConfigOverrides(options serveOptions, config *Config) {
 	if len(config.OAuth2.GrantTypes) == 0 {
 		config.OAuth2.GrantTypes = []string{
 			"authorization_code",
+			"certificate",
 			"implicit",
 			"password",
 			"refresh_token",

--- a/connector/cert/cert.go
+++ b/connector/cert/cert.go
@@ -1,0 +1,206 @@
+package cert
+
+import (
+	"crypto/x509"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+
+	"github.com/dexidp/dex/connector"
+)
+
+type Config struct {
+	// RootCAs are the paths of the certificates for client certificate validation
+	RootCAs []string `json:"rootCAs"`
+	// CertHeader is the name of the HTTP header containing the client certificate (if using a proxy)
+	CertHeader string `json:"certHeader"`
+
+	UserIDKey            string `json:"userIDKey"`
+	UserNameKey          string `json:"userNameKey"`
+	PreferredUserNameKey string `json:"preferredUserNameKey"`
+	GroupKey             string `json:"groupKey"`
+}
+
+// CertConnector implements the CallbackConnector interface
+type CertConnector struct {
+	rootCAs              []*x509.CertPool
+	certHeader           string
+	userIDKey            string
+	userNameKey          string
+	preferredUserNameKey string
+	groupKey             string
+	logger               *slog.Logger
+}
+
+// loadCACert loads the CA certificate from the file
+func loadCACert(caCertFile string) (*x509.CertPool, error) {
+	clientCA := x509.NewCertPool()
+	caCertBytes, err := os.ReadFile(caCertFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CA cert file: %v", err)
+	}
+
+	if !clientCA.AppendCertsFromPEM(caCertBytes) {
+		return nil, fmt.Errorf("no certs found in root CA file %q", caCertFile)
+	}
+
+	return clientCA, nil
+}
+
+// Open initializes the PKI Connector
+func (c *Config) Open(id string, logger *slog.Logger) (connector.Connector, error) {
+	if len(c.RootCAs) == 0 {
+		return nil, errors.New("missing required config field 'rootCAs'")
+	}
+
+	rootCAs := []*x509.CertPool{}
+	for _, rootCA := range c.RootCAs {
+		pool, err := loadCACert(rootCA)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load CA certificate: %v", err)
+		}
+		rootCAs = append(rootCAs, pool)
+	}
+
+	return &CertConnector{
+		rootCAs:              rootCAs,
+		certHeader:           c.CertHeader,
+		userIDKey:            c.UserIDKey,
+		userNameKey:          c.UserNameKey,
+		preferredUserNameKey: c.PreferredUserNameKey,
+		groupKey:             c.GroupKey,
+		logger:               logger,
+	}, nil
+}
+
+// Close is a no-op for this connector
+func (c *CertConnector) Close() error {
+	return nil
+}
+
+// ExtractCertificate extract the client certificate from the request
+func (c *CertConnector) ExtractCertificate(r *http.Request) (cert *x509.Certificate, err error) {
+	// Check if the certificate is in the TLS connector
+	if r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
+		return r.TLS.PeerCertificates[0], nil
+	}
+
+	// Check the header (for proxy cases)
+	if c.certHeader != "" {
+		certHeader := r.Header.Get(c.certHeader)
+		if certHeader != "" {
+			certData, err := base64.StdEncoding.DecodeString(certHeader)
+			if err != nil {
+				return nil, errors.New("failed decoding certificate")
+			}
+			cert, err := x509.ParseCertificate(certData)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse certificate: %v", err)
+			}
+			return cert, nil
+		}
+	}
+
+	return nil, errors.New("no client certificate found")
+}
+
+// ValidateCertificate validates the certificate against the CA pool
+func (c *CertConnector) ValidateCertificate(cert *x509.Certificate) (identity connector.Identity, err error) {
+	if cert == nil {
+		c.logger.Error("certificate validation failed", "error", "Certificate is nil")
+		return identity, fmt.Errorf("certificate validation failed: Certificate is nil")
+	}
+
+	// Verify the certificate against all configured rootCAs
+	// Only one must successfully verify the client certificate
+	validClientCertificate := true
+	verificationErrors := []error{}
+	for _, rootCA := range c.rootCAs {
+		validClientCertificate = true
+		_, err = cert.Verify(x509.VerifyOptions{
+			Roots:     rootCA,
+			KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		})
+		if err != nil {
+			validClientCertificate = false
+			verificationErrors = append(verificationErrors, err)
+		}
+		if validClientCertificate {
+			break
+		}
+	}
+	if !validClientCertificate {
+		c.logger.Error("certificate validation failed", "errors", verificationErrors)
+		return identity, fmt.Errorf("certificate validation failed: %v", verificationErrors)
+	}
+
+	// Extract value to be used as userID from certificate
+	var userID string
+	if c.userIDKey != "" {
+		userID = getValueFromCertificate(cert, c.userIDKey)
+	} else {
+		defaultUserIDKey := "0.9.2342.19200300.100.1.1" // OID for UID
+		userID = getValueFromCertificate(cert, defaultUserIDKey)
+	}
+	// safe guard
+	if userID == "" {
+		userID = cert.Subject.CommonName
+	}
+
+	// Extract value to be used as username from certificate
+	var userName string
+	if c.userNameKey != "" {
+		userName = getValueFromCertificate(cert, c.userNameKey)
+	} else {
+		userName = cert.Subject.CommonName
+	}
+
+	// Extract value to be used as preferredUsername from certificate
+	var preferredUserName string
+	if c.preferredUserNameKey != "" {
+		preferredUserName = getValueFromCertificate(cert, c.preferredUserNameKey)
+	} else {
+		preferredUserName = userName
+	}
+
+	// Extract email from certificate
+	var email string
+	if cert.EmailAddresses != nil && len(cert.EmailAddresses) > 0 {
+		email = cert.EmailAddresses[0]
+	}
+
+	// Extract organization from certificate (used as a group identifier)
+	var groups []string
+	if c.groupKey != "" {
+		groups = append(groups, getValueFromCertificate(cert, c.groupKey))
+	} else {
+		defaultGroupKey := "2.5.4.10" // OID for Organization
+		groups = append(groups, getValueFromCertificate(cert, defaultGroupKey))
+	}
+
+	// Extract identity information from the certificate
+	identity = connector.Identity{
+		UserID:            userID,
+		Username:          userName,
+		PreferredUsername: preferredUserName,
+		Email:             email,
+		EmailVerified:     false,
+		Groups:            groups,
+	}
+
+	return identity, nil
+}
+
+func getValueFromCertificate(cert *x509.Certificate, key string) string {
+	var value string
+	for _, name := range cert.Subject.Names {
+		if name.Type.String() == key {
+			value = name.Value.(string)
+			break
+		}
+	}
+	return value
+}

--- a/connector/cert/cert_test.go
+++ b/connector/cert/cert_test.go
@@ -1,0 +1,182 @@
+package cert
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/pem"
+	"log/slog"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpen(t *testing.T) {
+	// Create a temporary CA cert file for testing
+	caFile, err := os.CreateTemp("", "ca-*.pem")
+	assert.NoError(t, err, "Failed to create temp CA file")
+	defer os.Remove(caFile.Name())
+
+	// Generate a test CA certificate
+	caCert, _, err := generateCACertificate()
+	require.NoError(t, err, "Failed to generate CA certificate")
+
+	// Write the CA certificate into to the temp file
+	err = pem.Encode(caFile, &pem.Block{Type: "CERTIFICATE", Bytes: caCert.Raw})
+	require.NoError(t, err, "Failed to write CA cert to file")
+	caFile.Close()
+
+	// Create a config with the test CA cert file
+	config := Config{
+		RootCAs:    []string{caFile.Name()},
+		CertHeader: "X-Client-Cert",
+	}
+
+	// Create a logger
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	// Open the certConnector
+	conn, err := config.Open("test-connector", logger)
+	assert.NoError(t, err, "Failed to open connector")
+
+	// Check if it implements the connector interface
+	certConnector, ok := conn.(*CertConnector)
+	assert.True(t, ok, "Returned connector is not a certConnector")
+
+	assert.Equal(t, config.CertHeader, certConnector.certHeader, "Mismatched certHeader")
+}
+
+func TestExtractValidateCertificate(t *testing.T) {
+	// Generate a test CA certificate
+	caCert, caPrivKey, err := generateCACertificate()
+	require.NoError(t, err, "Failed to generate CA certificate")
+
+	// Generate a test client certificate
+	clientCert, err := generateClientCertificate(caCert, caPrivKey)
+	require.NoError(t, err, "Failed to generate client certificate")
+
+	caPool := x509.NewCertPool()
+	caPool.AddCert(caCert)
+
+	certConnector := &CertConnector{
+		rootCAs:    []*x509.CertPool{caPool},
+		certHeader: "X-Client-Cert",
+		logger:     slog.New(slog.NewTextHandler(os.Stdout, nil)),
+	}
+
+	// Test with valid certificate in TLS
+	t.Run("ValidCertificateTLS", func(t *testing.T) {
+		req := &http.Request{
+			TLS: &tls.ConnectionState{
+				PeerCertificates: []*x509.Certificate{clientCert},
+			},
+		}
+
+		cert, err := certConnector.ExtractCertificate(req)
+		assert.NoError(t, err, "ExtractCertificate failed")
+
+		identity, err := certConnector.ValidateCertificate(cert)
+		assert.NoError(t, err, "ValidateCertificate failed")
+		assert.Equal(t, "CUID2048", identity.UserID, "Unexpected UserID")
+	})
+	// Test with valid certificate in header
+	t.Run("ValidCertificateInHeader", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/callback", nil)
+		req.Header.Set("X-Client-Cert", base64.StdEncoding.EncodeToString(clientCert.Raw))
+
+		cert, err := certConnector.ExtractCertificate(req)
+		assert.NoError(t, err, "ExtractCertificate failed")
+
+		identity, err := certConnector.ValidateCertificate(cert)
+		assert.NoError(t, err, "HandleCallback failed")
+		assert.Equal(t, "CUID2048", identity.UserID, "Unexpected UserID")
+	})
+	// Test with no certificate
+	t.Run("NoCertificate", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/callback", nil)
+
+		_, err := certConnector.ExtractCertificate(req)
+		assert.Error(t, err, "Expected error for no certificate")
+	})
+}
+
+func generateCACertificate() (*x509.Certificate, *rsa.PrivateKey, error) {
+	caPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	caTemplate := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Country:      []string{"FR"},
+			Organization: []string{"Orange CA"},
+			CommonName:   "Test CA",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour * 24),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	caBytes, err := x509.CreateCertificate(rand.Reader, &caTemplate, &caTemplate, &caPrivKey.PublicKey, caPrivKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	caCert, err := x509.ParseCertificate(caBytes)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return caCert, caPrivKey, nil
+}
+
+func generateClientCertificate(caCert *x509.Certificate, caPrivKey *rsa.PrivateKey) (*x509.Certificate, error) {
+	clientPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
+
+	clientTemplate := x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject: pkix.Name{
+			Country:      []string{"FR"},
+			Organization: []string{"Orange"},
+			CommonName:   "Test Client",
+			ExtraNames: []pkix.AttributeTypeAndValue{
+				{
+					Type:  []int{0, 9, 2342, 19200300, 100, 1, 1}, // OID for UID
+					Value: "CUID2048",
+				},
+			},
+		},
+		NotBefore:   time.Now(),
+		NotAfter:    time.Now().Add(time.Hour * 24),
+		KeyUsage:    x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+
+	clientBytes, err := x509.CreateCertificate(rand.Reader, &clientTemplate, caCert, &clientPrivKey.PublicKey, caPrivKey)
+	if err != nil {
+		return nil, err
+	}
+
+	clientCert, err := x509.ParseCertificate(clientBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return clientCert, nil
+}

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -3,6 +3,7 @@ package connector
 
 import (
 	"context"
+	"crypto/x509"
 	"fmt"
 	"net/http"
 )
@@ -49,6 +50,14 @@ type Identity struct {
 	//
 	// This data is never shared with end users, OAuth clients, or through the API.
 	ConnectorData []byte
+}
+
+type CertificateConnector interface {
+	// ExtractCertificate extracts the certificate from the request.
+	ExtractCertificate(r *http.Request) (cert *x509.Certificate, err error)
+
+	// ValidateCertificate validates the certificate and returns the identity.
+	ValidateCertificate(cert *x509.Certificate) (identity Identity, err error)
 }
 
 // PasswordConnector is an interface implemented by connectors which take a

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -889,6 +889,8 @@ func (s *Server) handleToken(w http.ResponseWriter, r *http.Request) {
 		s.withClientFromStorage(w, r, s.handlePasswordGrant)
 	case grantTypeTokenExchange:
 		s.withClientFromStorage(w, r, s.handleTokenExchange)
+	case grantTypeCertificate:
+		s.withClientFromStorage(w, r, s.handleCertificateToken)
 	default:
 		s.tokenErrHelper(w, errUnsupportedGrantType, "", http.StatusBadRequest)
 	}
@@ -1459,6 +1461,118 @@ func (s *Server) handleTokenExchange(w http.ResponseWriter, r *http.Request, cli
 	w.Header().Set("Pragma", "no-cache")
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(resp)
+}
+
+func (s *Server) handleCertificateToken(w http.ResponseWriter, r *http.Request, client storage.Client) {
+	if err := r.ParseForm(); err != nil {
+		s.tokenErrHelper(w, errInvalidRequest, "", http.StatusBadRequest)
+		return
+	}
+	q := r.Form
+
+	nonce := q.Get("nonce")
+	if nonce == "" {
+		s.tokenErrHelper(w, errInvalidRequest, "No nonce provided", http.StatusBadRequest)
+		return
+	}
+
+	scopes := strings.Fields(q.Get("scope"))
+	// Parse the scopes if they are passed
+	var (
+		unrecognized  []string
+		invalidScopes []string
+	)
+	hasOpenIDScope := false
+	for _, scope := range scopes {
+		switch scope {
+		case scopeOpenID:
+			hasOpenIDScope = true
+		case scopeOfflineAccess, scopeEmail, scopeProfile, scopeGroups, scopeFederatedID:
+		default:
+			peerID, ok := parseCrossClientScope(scope)
+			if !ok {
+				unrecognized = append(unrecognized, scope)
+				continue
+			}
+
+			isTrusted, err := s.validateCrossClientTrust(r.Context(), client.ID, peerID)
+			if err != nil {
+				s.tokenErrHelper(w, errInvalidClient, fmt.Sprintf("Error validating cross client trust %v.", err), http.StatusBadRequest)
+				return
+			}
+			if !isTrusted {
+				invalidScopes = append(invalidScopes, scope)
+			}
+		}
+	}
+	if !hasOpenIDScope {
+		s.tokenErrHelper(w, errInvalidRequest, `Missing required scope(s) ["openid"].`, http.StatusBadRequest)
+		return
+	}
+	if len(unrecognized) > 0 {
+		s.tokenErrHelper(w, errInvalidRequest, fmt.Sprintf("Unrecognized scope(s) %q", unrecognized), http.StatusBadRequest)
+		return
+	}
+	if len(invalidScopes) > 0 {
+		s.tokenErrHelper(w, errInvalidRequest, fmt.Sprintf("Client can't request scope(s) %q", invalidScopes), http.StatusBadRequest)
+		return
+	}
+
+	connID := q.Get("connector_id")
+	if connID == "" {
+		s.tokenErrHelper(w, errInvalidRequest, "No connector_id provided", http.StatusBadRequest)
+		return
+	}
+
+	conn, err := s.getConnector(r.Context(), connID)
+	if err != nil {
+		s.tokenErrHelper(w, errInvalidRequest, "Invalid connector_id", http.StatusBadRequest)
+		return
+	}
+
+	certConnector, ok := conn.Connector.(connector.CertificateConnector)
+	if !ok {
+		s.tokenErrHelper(w, errInvalidRequest, "Connector does not support certificate authentication", http.StatusBadRequest)
+		return
+	}
+
+	cert, err := certConnector.ExtractCertificate(r)
+	if err != nil {
+		s.tokenErrHelper(w, errInvalidRequest, "Invalid certificate", http.StatusBadRequest)
+		return
+	}
+
+	identity, err := certConnector.ValidateCertificate(cert)
+	if err != nil {
+		s.tokenErrHelper(w, errInvalidRequest, "Unable to validate certificate", http.StatusBadRequest)
+		return
+	}
+
+	claims := storage.Claims{
+		UserID:            identity.UserID,
+		Username:          identity.Username,
+		PreferredUsername: identity.PreferredUsername,
+		Email:             identity.Email,
+		EmailVerified:     identity.EmailVerified,
+		Groups:            identity.Groups,
+	}
+
+	accessToken, _, err := s.newAccessToken(r.Context(), q.Get("client_id"), claims, scopes, nonce, connID)
+	if err != nil {
+		s.logger.ErrorContext(r.Context(), "certificate grant failed to create new access token", "err", err)
+		s.tokenErrHelper(w, errServerError, "", http.StatusInternalServerError)
+		return
+	}
+
+	idToken, expiry, err := s.newIDToken(r.Context(), q.Get("client_id"), claims, scopes, nonce, accessToken, "", connID)
+	if err != nil {
+		s.logger.ErrorContext(r.Context(), "certificate grant failed to create new ID token", "err", err)
+		s.tokenErrHelper(w, errServerError, "", http.StatusInternalServerError)
+		return
+	}
+
+	resp := s.toAccessTokenResponse(idToken, accessToken, "", expiry)
+	s.writeAccessToken(w, resp)
 }
 
 type accessTokenResponse struct {

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -62,6 +62,7 @@ func TestHandleDiscovery(t *testing.T) {
 		Introspect:     fmt.Sprintf("%s/token/introspect", httpServer.URL),
 		GrantTypes: []string{
 			"authorization_code",
+			"certificate",
 			"refresh_token",
 			"urn:ietf:params:oauth:grant-type:device_code",
 			"urn:ietf:params:oauth:grant-type:token-exchange",

--- a/server/oauth2.go
+++ b/server/oauth2.go
@@ -143,6 +143,7 @@ const (
 	grantTypePassword          = "password"
 	grantTypeDeviceCode        = "urn:ietf:params:oauth:grant-type:device_code"
 	grantTypeTokenExchange     = "urn:ietf:params:oauth:grant-type:token-exchange"
+	grantTypeCertificate       = "certificate"
 )
 
 const (

--- a/server/server.go
+++ b/server/server.go
@@ -31,6 +31,7 @@ import (
 	"github.com/dexidp/dex/connector/atlassiancrowd"
 	"github.com/dexidp/dex/connector/authproxy"
 	"github.com/dexidp/dex/connector/bitbucketcloud"
+	"github.com/dexidp/dex/connector/cert"
 	"github.com/dexidp/dex/connector/gitea"
 	"github.com/dexidp/dex/connector/github"
 	"github.com/dexidp/dex/connector/gitlab"
@@ -233,6 +234,7 @@ func newServer(ctx context.Context, c Config) (*Server, error) {
 		grantTypeRefreshToken:      true,
 		grantTypeDeviceCode:        true,
 		grantTypeTokenExchange:     true,
+		grantTypeCertificate:       true,
 	}
 	supportedRes := make(map[string]bool)
 
@@ -691,6 +693,7 @@ var ConnectorsConfig = map[string]func() ConnectorConfig{
 	"bitbucket-cloud": func() ConnectorConfig { return new(bitbucketcloud.Config) },
 	"openshift":       func() ConnectorConfig { return new(openshift.Config) },
 	"atlassian-crowd": func() ConnectorConfig { return new(atlassiancrowd.Config) },
+	"cert":            func() ConnectorConfig { return new(cert.Config) },
 	// Keep around for backwards compatibility.
 	"samlExperimental": func() ConnectorConfig { return new(saml.Config) },
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -107,6 +107,7 @@ func newTestServer(t *testing.T, updateConfig func(c *Config)) (*httptest.Server
 			grantTypeTokenExchange,
 			grantTypeImplicit,
 			grantTypePassword,
+			grantTypeCertificate,
 		},
 		Signer: sig,
 	}
@@ -1774,7 +1775,7 @@ func TestServerSupportedGrants(t *testing.T) {
 		{
 			name:      "Simple",
 			config:    func(c *Config) {},
-			resGrants: []string{grantTypeAuthorizationCode, grantTypeRefreshToken, grantTypeDeviceCode, grantTypeTokenExchange},
+			resGrants: []string{grantTypeAuthorizationCode, grantTypeCertificate, grantTypeRefreshToken, grantTypeDeviceCode, grantTypeTokenExchange},
 		},
 		{
 			name:      "Minimal",
@@ -1784,12 +1785,12 @@ func TestServerSupportedGrants(t *testing.T) {
 		{
 			name:      "With password connector",
 			config:    func(c *Config) { c.PasswordConnector = "local" },
-			resGrants: []string{grantTypeAuthorizationCode, grantTypePassword, grantTypeRefreshToken, grantTypeDeviceCode, grantTypeTokenExchange},
+			resGrants: []string{grantTypeAuthorizationCode, grantTypeCertificate, grantTypePassword, grantTypeRefreshToken, grantTypeDeviceCode, grantTypeTokenExchange},
 		},
 		{
 			name:      "With token response",
 			config:    func(c *Config) { c.SupportedResponseTypes = append(c.SupportedResponseTypes, responseTypeToken) },
-			resGrants: []string{grantTypeAuthorizationCode, grantTypeImplicit, grantTypeRefreshToken, grantTypeDeviceCode, grantTypeTokenExchange},
+			resGrants: []string{grantTypeAuthorizationCode, grantTypeCertificate, grantTypeImplicit, grantTypeRefreshToken, grantTypeDeviceCode, grantTypeTokenExchange},
 		},
 		{
 			name: "All",
@@ -1797,7 +1798,7 @@ func TestServerSupportedGrants(t *testing.T) {
 				c.PasswordConnector = "local"
 				c.SupportedResponseTypes = append(c.SupportedResponseTypes, responseTypeToken)
 			},
-			resGrants: []string{grantTypeAuthorizationCode, grantTypeImplicit, grantTypePassword, grantTypeRefreshToken, grantTypeDeviceCode, grantTypeTokenExchange},
+			resGrants: []string{grantTypeAuthorizationCode, grantTypeCertificate, grantTypeImplicit, grantTypePassword, grantTypeRefreshToken, grantTypeDeviceCode, grantTypeTokenExchange},
 		},
 	}
 


### PR DESCRIPTION
Example connector config:
```yaml
connectors:
  - type: cert
    name: PKI Connector
    id: pki
    config:
      rootCAs:
        - /usr/share/ca-certificates/Orange/oig2_userclass2_ca.cer
      certHeader: "X-Client-Cert"
      # userIDKey: ""
      userNameKey: "0.9.2342.19200300.100.1.1"
      # preferredUsernameKey: ""
      # groupKey: ""
```